### PR TITLE
Hao's code smells fixes

### DIFF
--- a/public/js/ServerInteractor.js
+++ b/public/js/ServerInteractor.js
@@ -19,7 +19,7 @@ class ServerInteractor {
     req.send();
   }
 
-  getIngredientInfo(callback, ingredient_id) {
+  getIngredientInfo(ingredient_id, callback) {
     let req = new XMLHttpRequest();
     req.open('POST', this.baseUrl + '/getIngredientForCustomRecipe', true);
     req.setRequestHeader('Content-Type', 'application/json');

--- a/public/js/TableBuilder.js
+++ b/public/js/TableBuilder.js
@@ -1,0 +1,11 @@
+class TableBuilder {
+  constructor(body) {
+    this.body = body;
+  }
+
+  createRow() {
+    let row = document.createElement('tr');
+    this.body.appendChild(row);
+    return row;
+  }
+}

--- a/public/js/TableBuilder.js
+++ b/public/js/TableBuilder.js
@@ -8,4 +8,11 @@ class TableBuilder {
     this.body.appendChild(row);
     return row;
   }
+
+  createTextOnlyCell(row, textContent) {
+    let cell = document.createElement('td');
+    cell.textContent = textContent;
+    row.appendChild(cell);
+    return cell;
+  }
 }

--- a/public/js/TableBuilder.js
+++ b/public/js/TableBuilder.js
@@ -15,4 +15,15 @@ class TableBuilder {
     row.appendChild(cell);
     return cell;
   }
+
+  createButtonCell(row, buttonText, buttonFunction) {
+    let cell = document.createElement('td');
+    row.appendChild(cell);
+
+    let button = document.createElement('button');
+    cell.appendChild(button);
+    button.textContent = buttonText;
+    button.addEventListener('click', buttonFunction);
+    return cell;
+  }
 }

--- a/public/js/build/BuildRecipeFunctionFactory.js
+++ b/public/js/build/BuildRecipeFunctionFactory.js
@@ -55,4 +55,18 @@ class BuildRecipeFunctionFactory {
       delete brvc.recipe_ingredients[ingredient_id];
     }
   }
+
+  createInfoFunction(ingredient_id) {
+    return function () {
+      let si = new ServerInteractor();
+
+      si.getIngredientInfo(ingredient_id, (result) => {
+        console.log(result);
+        // Update Ingredient Info box on page async
+        document.getElementById("ingredient-name").textContent = result.ingredient;
+        document.getElementById("ingredient-ethics").textContent = result.problem;
+        document.getElementById("ingredient-alternatives").innerHTML = result.alternative.join("<br>");
+      })
+    }
+  }
 } 

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -34,19 +34,12 @@ class BuildRecipeViewController {
         tb.createTextOnlyCell(row, ingredient_name);
 
         // Add an "Add to recipe" button
-        let addButton = document.createElement('button');
-        addButton.textContent = "Add";
-
         // Use the BuildRecipeFunctionFactory to create an add ingredient function
         let ff = new BuildRecipeFunctionFactory();
         let addFunction = ff.createAddIngredientFunction(ingredient_id, ingredient_name, this);
+        tb.createButtonCell(row, 'Add', addFunction);
 
-        // When user clicks on the Add button, add it to the recipe table
-        addButton.addEventListener('click', addFunction);
-        // Append the add button to the ingredient row
-        row.appendChild(addButton);
-
-        //Add an "Info" button
+        // Add an "Info" button
         let infoButton = document.createElement('button');
         infoButton.textContent = "Info";
         // When user clicks on Info button, ingredient info show ups asynchronously on page

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -27,15 +27,11 @@ class BuildRecipeViewController {
 
         // Add the ID cell
         let ingredient_id = ingredients[i]['id'];
-        let id_cell = document.createElement('td');
-        id_cell.textContent = ingredient_id;
-        row.appendChild(id_cell);
+        tb.createTextOnlyCell(row, ingredient_id);
 
         // Add the name cell
         let ingredient_name = ingredients[i]['name'];
-        let name_cell = document.createElement('td');
-        name_cell.textContent = ingredient_name;
-        row.appendChild(name_cell);
+        tb.createTextOnlyCell(row, ingredient_name);
 
         // Add an "Add to recipe" button
         let addButton = document.createElement('button');

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -20,9 +20,10 @@ class BuildRecipeViewController {
     si.getAllIngredients((ingredients) => {
 
       let ingredients_table_body = document.getElementById("ingredients-table-body");
+      let tb = new TableBuilder(ingredients_table_body);
 
       for (let i = 0; i < ingredients.length; i++) {
-        let row = document.createElement('tr');
+        let row = tb.createRow();
 
         // Add the ID cell
         let ingredient_id = ingredients[i]['id'];
@@ -56,9 +57,6 @@ class BuildRecipeViewController {
         let infoFunction = ff.createInfoFunction(ingredient_id);
         infoButton.addEventListener('click', infoFunction);
         row.appendChild(infoButton);
-
-        // Add the row
-        ingredients_table_body.appendChild(row);
       }
     });
   }

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -53,16 +53,8 @@ class BuildRecipeViewController {
         let infoButton = document.createElement('button');
         infoButton.textContent = "Info";
         // When user clicks on Info button, ingredient info show ups asynchronously on page
-        infoButton.addEventListener('click', function() {
-          function myCallback(result) {
-            console.log(result);
-            // Update Ingredient Info box on page async
-            document.getElementById("ingredient-name").textContent = result.ingredient;
-            document.getElementById("ingredient-ethics").textContent = result.problem;
-            document.getElementById("ingredient-alternatives").innerHTML = result.alternative.join("<br>");
-          }
-          si.getIngredientInfo(myCallback, ingredient_id);
-        });
+        let infoFunction = ff.createInfoFunction(ingredient_id);
+        infoButton.addEventListener('click', infoFunction);
         row.appendChild(infoButton);
 
         // Add the row

--- a/views/build.handlebars
+++ b/views/build.handlebars
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <p1>Build a Recipe</p1>
 <div>
     <label for="recipe_name">Recipe Name:</label>

--- a/views/build.handlebars
+++ b/views/build.handlebars
@@ -54,6 +54,7 @@
 </table>
 
 <script type="text/javascript" src='/js/ServerInteractor.js'></script>
+<script type="text/javascript" src='/js/TableBuilder.js'></script>
 <script type="text/javascript" src='/js/build/BuildRecipeViewController.js'></script>
 <script type="text/javascript" src='/js/build/BuildRecipeFunctionFactory.js'></script>
 <link rel="stylesheet" type="text/css" href="css/build.css">


### PR DESCRIPTION
My refactoring is focused on the Build a Recipe feature and view. By extracting common table manipulation code (such as `createRow`, `createTextOnlyCell`, and `createButtonCell`) into a stand alone `TableBuilder` class, the changes help reduce length of the `loadPageContent` method of the client class `BuildRecipeViewController`.

The changes primarily address the Long Method and Large Class code smells.