### PR TITLE
Add a Procfile for Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node main.js


### PR DESCRIPTION
A `Procfile` is required for deploying to Heroku.