### PR TITLE
Consolidate recipe and ingredients routes

### DIFF
--- a/main.js
+++ b/main.js
@@ -169,7 +169,7 @@ app.get('/category/:category',function(req,res,next){
   context.title = type;
 
   // Select all from the test_table
-  let query = `select r.name as recipename, c.name as categoryname
+  let query = `select r.id as recipeid ,r.name as recipename, c.name as categoryname
                   from category c
                   inner join recipe_category rc on c.id = rc.category_id
                   inner join recipe r on rc.recipe_id = r.id
@@ -184,37 +184,6 @@ app.get('/category/:category',function(req,res,next){
 
     context.results = result.rows;
     res.render('category', context);
-  });
-});
-
-
-
-/*
-dispay ingredients for recipes
-*/
-
-app.get('/ingredients/:recipename', function(req,res, next){
-  let context = {};
-  context.user = req.user || null  // req.user exists when a user is logged in
-  var recipe = req.params.recipename;
-  context.title = "Ethical Eating - " + recipe;
-
-  // Select all from the test_table
-  let query = `select r.name as recipeName, i.name as ingredientList
-              from recipe r
-              inner join recipe_ingredient ri on r.id = ri.recipe_id 
-              inner join ingredient i on ri.ingredient_id = i.id
-              where r.name = $1`;
-
-  var inserts = [recipe];
-  pg.query(query, inserts, (err, result) => {
-    if(err){
-      next(err);
-      return;
-    }
-
-    context.results = result.rows;
-    res.render('ingredients', context);
   });
 });
 

--- a/views/category.handlebars
+++ b/views/category.handlebars
@@ -2,7 +2,7 @@
 <p>{{#each results}}{{#if @first}}{{this.categoryname}}{{/if}}{{/each}} Recipes</p>
 <ul>
     {{#each results}}
-        <li><a href='/ingredients/{{this.recipename}}'><p>{{this.recipename}}</p></a></li>
+        <li><a href='/recipe?id={{this.recipeid}}'><p>{{this.recipename}}</p></a></li>
     {{/each}}
 </ul>
 


### PR DESCRIPTION
This PR removes the `/ingredients` end point on the server side and replaces all references to `/ingredients` (in `views/category.handlebars`) with references to `/recipe`.