### PR TITLE
Edit and customize recipes

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,8 @@ app.get('/recipe', function (req, res, next) {
 
   let recipe_id = req.query.id;
   let query = {
-    text: `select i.name as ingredientname, r.name as recipename from recipe r 
+    text: `select i.name as ingredientname, r.name as recipename, r.owner_id as ownerid, r.id as recipeid 
+           from recipe r
            inner join recipe_ingredient ri on r.id = ri.recipe_id 
            inner join ingredient i on ri.ingredient_id = i.id 
            where r.id = $1`,

--- a/main.js
+++ b/main.js
@@ -137,7 +137,7 @@ app.get('/recipe', function (req, res, next) {
 
   let recipe_id = req.query.id;
   let query = {
-    text: `select i.name as ingredientname, r.name as recipename, r.owner_id as ownerid, r.id as recipeid 
+    text: `select i.name as ingredientname, r.name as recipename, r.owner_id as ownerid, r.id as recipeid
            from recipe r
            inner join recipe_ingredient ri on r.id = ri.recipe_id 
            inner join ingredient i on ri.ingredient_id = i.id 
@@ -154,9 +154,30 @@ app.get('/recipe', function (req, res, next) {
     context.results = result.rows;
 
     res.render('recipe', context);
-
   })
+});
 
+app.post('/getRecipeIngredientsWithRecipeId', function (req, res, next) {
+
+  let recipe_id = req.body.id;
+  let query = {
+    text: `select i.name as ingredientname, r.name as recipename, r.owner_id as ownerid, r.id as recipeid, i.id as ingredientid
+           from recipe r
+           inner join recipe_ingredient ri on r.id = ri.recipe_id 
+           inner join ingredient i on ri.ingredient_id = i.id 
+           where r.id = $1`,
+    values: [recipe_id]
+  };
+
+  pg.query(query, (err, result) => {
+    if (err) {
+      next(err);
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    res.send(JSON.stringify(result.rows));
+  })
 });
 
 /*

--- a/main.js
+++ b/main.js
@@ -210,34 +210,40 @@ app.delete('/deleteRecipeWithId', (req, res, next) => {
 
   let recipe_id = req.body.id;
 
-  // First delete the ingredient associations
-  let recipe_ingredient_del_query = {
-    text: `delete from recipe_ingredient ri where ri.recipe_id = $1`,
-    values: [recipe_id]
-  };
-
-  pg.query(recipe_ingredient_del_query, (err, result) => {
-    if (err) {
-      next(err);
-      return;
-    }
-
-    // Then delete the recipe itself
-    let recipe_del_query = {
-      text: `delete from recipe r where r.id = $1 returning *`,
+  // First delete the recipe ingredient entries
+  let promise_del_recipe_ingredient = new Promise(function (resolve, reject) {
+    let recipe_ingredient_del_query = {
+      text: `delete from recipe_ingredient ri where ri.recipe_id = $1 returning *`,
       values: [recipe_id]
     };
 
-    pg.query(recipe_del_query, (err, result) => {
+    pg.query(recipe_ingredient_del_query, (err, result) => {
       if (err) {
-        next(err);
-        return;
+        reject(err);
       }
-
-      res.setHeader('Content-Type', 'application/json');
-      res.send(JSON.stringify(result.rows));
+      resolve(result);
     });
   });
+
+  // Once the first promise resolves (recipe-ingredient entries deleted), then delete the recipe entry
+  promise_del_recipe_ingredient
+    .then(recipe_ingredient_result => new Promise(((resolve, reject) => {
+        let recipe_del_query = {
+          text: `delete from recipe r where r.id = $1 returning *`,
+          values: [recipe_id]
+        };
+        pg.query(recipe_del_query, (err, result) => {
+          if (err) {
+            reject(err);
+          }
+
+          res.setHeader('Content-Type', 'application/json');
+          res.send(JSON.stringify(result.rows));
+        });
+    })))
+
+    // Handle any error in the promise chain
+    .catch(error => next(error));
 });
 
 /*

--- a/main.js
+++ b/main.js
@@ -206,6 +206,40 @@ app.post('/findPrivateRecipeWithName', (req, res, next) => {
   })
 });
 
+app.delete('/deleteRecipeWithId', (req, res, next) => {
+
+  let recipe_id = req.body.id;
+
+  // First delete the ingredient associations
+  let recipe_ingredient_del_query = {
+    text: `delete from recipe_ingredient ri where ri.recipe_id = $1`,
+    values: [recipe_id]
+  };
+
+  pg.query(recipe_ingredient_del_query, (err, result) => {
+    if (err) {
+      next(err);
+      return;
+    }
+
+    // Then delete the recipe itself
+    let recipe_del_query = {
+      text: `delete from recipe r where r.id = $1 returning *`,
+      values: [recipe_id]
+    };
+
+    pg.query(recipe_del_query, (err, result) => {
+      if (err) {
+        next(err);
+        return;
+      }
+
+      res.setHeader('Content-Type', 'application/json');
+      res.send(JSON.stringify(result.rows));
+    });
+  });
+});
+
 /*
 display on category page based on click
 */

--- a/main.js
+++ b/main.js
@@ -210,7 +210,7 @@ app.delete('/deleteRecipeWithId', (req, res, next) => {
 
   let recipe_id = req.body.id;
 
-  // Wrap the code in an annonymous async function so we can use the async-await syntax
+  // Wrap the code in an anonymous async function so we can use the async-await syntax
   (async () => {
 
     // Use a try-catch block to catch errors from async-await

--- a/main.js
+++ b/main.js
@@ -180,6 +180,32 @@ app.post('/getRecipeIngredientsWithRecipeId', function (req, res, next) {
   })
 });
 
+app.post('/findPrivateRecipeWithName', (req, res, next) => {
+
+  // Check that there is an active user session
+  if (!req.user) {
+    res.send({error: 'You have to log in first!'});
+  }
+
+  let name = req.body.name;
+  let owner_id = req.user.id;
+
+  let query = {
+    text: `select * from recipe r where name like $1 and owner_id = $2`,
+    values: [name, owner_id]
+  };
+
+  pg.query(query, (err, result) => {
+    if (err) {
+      next(err);
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    res.send(JSON.stringify(result.rows));
+  })
+});
+
 /*
 display on category page based on click
 */
@@ -256,9 +282,6 @@ app.post('/getEthicalProblemForIngredientId', function (req, res, next) {
     res.send(JSON.stringify(result.rows));
   });
 });
-
-
-
 
 /*
 The /getRecipeByCategory endpoint takes an id of a category as a parameter and returns a list of all the recipes within that category

--- a/public/js/ServerInteractor.js
+++ b/public/js/ServerInteractor.js
@@ -64,4 +64,19 @@ class ServerInteractor {
     });
     req.send(payload);
   }
+
+  findPrivateRecipeWithName(name, callback) {
+    let req = new XMLHttpRequest();
+    req.open('POST', this.baseUrl + '/findPrivateRecipeWithName', true);
+    req.setRequestHeader('Content-Type', 'application/json');
+    let payload = JSON.stringify({"name": name});
+    req.addEventListener('load', function() {
+      if(req.status >= 200 && req.status < 400) {
+        callback(JSON.parse(req.responseText));
+      } else {
+        console.log("Error in network request: " + req.statusText);
+      }
+    });
+    req.send(payload);
+  }
 }

--- a/public/js/ServerInteractor.js
+++ b/public/js/ServerInteractor.js
@@ -49,4 +49,19 @@ class ServerInteractor {
 
     req.send(payload);
   }
+
+  getRecipeIngredients(recipe_id, callback) {
+    let req = new XMLHttpRequest();
+    req.open('POST', this.baseUrl + '/getRecipeIngredientsWithRecipeId', true);
+    req.setRequestHeader('Content-Type', 'application/json');
+    let payload = JSON.stringify({"id":recipe_id});
+    req.addEventListener('load', function() {
+      if(req.status >= 200 && req.status < 400) {
+        callback(JSON.parse(req.responseText));
+      } else {
+        console.log("Error in network request: " + req.statusText);
+      }
+    });
+    req.send(payload);
+  }
 }

--- a/public/js/ServerInteractor.js
+++ b/public/js/ServerInteractor.js
@@ -79,4 +79,19 @@ class ServerInteractor {
     });
     req.send(payload);
   }
+
+  deleteRecipeWithId(id, callback) {
+    let req = new XMLHttpRequest();
+    req.open('DELETE', this.baseUrl + '/deleteRecipeWithId', true);
+    req.setRequestHeader('Content-Type', 'application/json');
+    let payload = JSON.stringify({"id": id});
+    req.addEventListener('load', function() {
+      if(req.status >= 200 && req.status < 400) {
+        callback(JSON.parse(req.responseText));
+      } else {
+        console.log("Error in network request: " + req.statusText);
+      }
+    });
+    req.send(payload);
+  }
 }

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -98,7 +98,6 @@ class BuildRecipeViewController {
       recipe_name_field.value = results[0].recipename;
 
       for (let i = 0; i < results.length; i++) {
-        console.log(results[i]);
         let ingredient_id = results[i].ingredientid;
         let ingredient_name = results[i].ingredientname;
 

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -98,8 +98,14 @@ class BuildRecipeViewController {
           }
           // User wants to overwrite
           else {
-            // todo: Delete the existing recipe
+            let recipe_id = response[0].id;
 
+            let si = new ServerInteractor();
+            si.deleteRecipeWithId(recipe_id, (response) => {
+              if (response[0].id === recipe_id) {
+                console.log(`Recipe ${recipe_id} was deleted!`);
+              }
+            });
           }
         }
 

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -55,7 +55,7 @@ class BuildRecipeViewController {
 
     // If a recipe ID is passed in the URL, pre-populate the page with ingredients from that recipe
     if (recipe_id) {
-
+      this.prepopulateWithRecipe(recipe_id);
     }
   }
 
@@ -88,8 +88,24 @@ class BuildRecipeViewController {
     });
   }
 
-  prepopulateWithRecipe() {
+  prepopulateWithRecipe(recipe_id) {
+    let si = new ServerInteractor();
+    let ff = new BuildRecipeFunctionFactory();
 
+    si.getRecipeIngredients(recipe_id, (results) => {
+
+      let recipe_name_field = document.getElementById("recipe_name");
+      recipe_name_field.value = results[0].recipename;
+
+      for (let i = 0; i < results.length; i++) {
+        console.log(results[i]);
+        let ingredient_id = results[i].ingredientid;
+        let ingredient_name = results[i].ingredientname;
+
+        let addFunc = ff.createAddIngredientFunction(ingredient_id, ingredient_name, this);
+        addFunc();
+      }
+    })
   }
 }
 

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -48,6 +48,15 @@ class BuildRecipeViewController {
         info_cell.children[0].setAttribute("id", "Info" + ingredient_id);
       }
     });
+
+    // Get access to the recipeid parameters in the URL
+    const url_params = new URLSearchParams(window.location.search);
+    let recipe_id = url_params.get('recipeid');
+
+    // If a recipe ID is passed in the URL, pre-populate the page with ingredients from that recipe
+    if (recipe_id) {
+
+    }
   }
 
   saveRecipe() {
@@ -77,6 +86,10 @@ class BuildRecipeViewController {
         alert("Recipe was saved successfully!");
       }
     });
+  }
+
+  prepopulateWithRecipe() {
+
   }
 }
 

--- a/public/js/build/BuildRecipeViewController.js
+++ b/public/js/build/BuildRecipeViewController.js
@@ -78,12 +78,40 @@ class BuildRecipeViewController {
 
     // Save the recipe
     let si = new ServerInteractor();
-    si.saveRecipe(name, this.recipe_ingredients, (response) => {
+
+    // Check if the user already has a recipe with the same name
+    si.findPrivateRecipeWithName(name, (response) => {
       if (response.error) {
         alert(response.error);
       }
+      // There was no error
       else {
-        alert("Recipe was saved successfully!");
+        console.log(response);
+
+        // If an recipe with the same name already exists
+        if (response.length > 0) {
+          let override = confirm("A recipe with the same name already exists. Are you sure you want to overwrite it?");
+
+          // User does not want to overwrite, return
+          if (!override) {
+            return;
+          }
+          // User wants to overwrite
+          else {
+            // todo: Delete the existing recipe
+
+          }
+        }
+
+        // Save the recipe
+        si.saveRecipe(name, this.recipe_ingredients, (response) => {
+          if (response.error) {
+            alert(response.error);
+          }
+          else {
+            alert("Recipe was saved successfully!");
+          }
+        });
       }
     });
   }
@@ -94,13 +122,16 @@ class BuildRecipeViewController {
 
     si.getRecipeIngredients(recipe_id, (results) => {
 
+      // Populate the recipe name field
       let recipe_name_field = document.getElementById("recipe_name");
       recipe_name_field.value = results[0].recipename;
 
+      // Add the ingredients
       for (let i = 0; i < results.length; i++) {
         let ingredient_id = results[i].ingredientid;
         let ingredient_name = results[i].ingredientname;
 
+        // Create a function for adding the ingredient and then call the function
         let addFunc = ff.createAddIngredientFunction(ingredient_id, ingredient_name, this);
         addFunc();
       }

--- a/views/recipe.handlebars
+++ b/views/recipe.handlebars
@@ -14,8 +14,8 @@
 
 <div>
     {{#if results.1.ownerid}}
-        <a href="/build?recipeid={{results.1.recipeid}}">Edit this private recipe</a>
+        <a href="/build?recipeid={{results.0.recipeid}}">Edit this private recipe</a>
     {{else}}
-        <a href="/build?recipeid={{results.1.recipeid}}">Customize this public recipe</a>
+        <a href="/build?recipeid={{results.0.recipeid}}">Customize this public recipe</a>
     {{/if}}
 </div>

--- a/views/recipe.handlebars
+++ b/views/recipe.handlebars
@@ -1,15 +1,21 @@
 <div class="viewCat">
 
-<a href="javascript:history.back()">Return to View Recipes</a>
+    <a href="javascript:history.back()">Return to View Recipes</a>
 
 </div>
 <div>
+    <p>View {{#each results}}{{#if @first}}{{this.recipename}}{{/if}}{{/each}} Ingredients</p>
+    <ul>
+        {{#each results}}
+            <li>{{this.ingredientname}}</li>
+        {{/each}}
+    </ul>
+</div>
 
-<p>View {{#each results}}{{#if @first}}{{this.recipename}}{{/if}}{{/each}} Ingredients</p>
-<ul>
-    {{#each results}}
-        <li>{{this.ingredientname}}</li>
-    {{/each}}
-</ul>
-
+<div>
+    {{#if results.1.ownerid}}
+        <a href="/build?recipeid={{results.1.recipeid}}">Edit this private recipe</a>
+    {{else}}
+        <a href="/build?recipeid={{results.1.recipeid}}">Customize this public recipe</a>
+    {{/if}}
 </div>


### PR DESCRIPTION
With this PR, users can now do the following:
* Customize a copy of a public recipe and (if logged in) save a private copy of the customized recipe
* Edit a saved private recipe, and save the changes
* Choose to overwrite a saved recipe with a same recipe name

For customizing a public recipe and editing a saved private recipe, the implementation I chose is to go to the `/build` page, but pre-populating the list of added ingredients and recipe name field. This allows us to take full advantage of the code we wrote for Build a Recipe (add, remove, replace, info, etc).

It is worth pointing out that when a user chooses to overwrite an existing recipe with a same name, the app **deletes** that existing recipe and all associated ingredients from the database, and then saves a new recipe entry. This means the newly saved recipe will have the same name as the previous one, but a **different recipe ID**.